### PR TITLE
Call entity.destroy() with raise_destroy = true

### DIFF
--- a/scripts/util.lua
+++ b/scripts/util.lua
@@ -308,7 +308,7 @@ function util.destroy_entity_and_raise_event(entity, destroyer_player, is_instan
 		-- Some mods like to make sure the entity is really dead.
 		return true
 	end
-	if entity.destroy() then
+	if entity.destroy({raise_destroy = true}) then
 		return true
 	end
 	return false


### PR DESCRIPTION
Please add the raise_destroy = true parameter to entity.destroy(). This was added in the past couple years and works much better than the ugly on_pre_robot_mined hack.