### PR TITLE
0.18.2 update fix

### DIFF
--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "creative-mod",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "title": "Creative Mod",
   "author": "Y.Petremann, rk84, Mooncat, Chrisgbk, jodli",
   "homepage": "https://forums.factorio.com/viewtopic.php?f=97&t=28005",

--- a/prototypes/entity.lua
+++ b/prototypes/entity.lua
@@ -800,6 +800,44 @@ local function alien_attractor_proxy(entity_name, mark_scale)
 	}
 end
 
+local function flying_robot_sounds(volume)
+  return {
+		sound = 
+		{
+      { 
+        filename = "__base__/sound/construction-robot-1.ogg", volume = volume 
+      },
+      { 
+        filename = "__base__/sound/construction-robot-2.ogg", volume = volume
+      },
+      { 
+        filename = "__base__/sound/construction-robot-3.ogg", volume = volume 
+      },
+      { 
+        filename = "__base__/sound/construction-robot-4.ogg", volume = volume 
+      },
+      { 
+        filename = "__base__/sound/construction-robot-5.ogg", volume = volume 
+      },
+      { 
+        filename = "__base__/sound/construction-robot-6.ogg", volume = volume 
+      },
+      { 
+        filename = "__base__/sound/construction-robot-7.ogg", volume = volume 
+      },
+      { 
+        filename = "__base__/sound/construction-robot-8.ogg", volume = volume 
+      },
+      { 
+        filename = "__base__/sound/construction-robot-9.ogg", volume = volume 
+      }
+    },
+    max_sounds_per_type = 1,
+    audible_distance_modifier = 1,
+    probability = 1 / (10 * 60) -- average pause between the sound is 10 seconds
+  }
+end
+
 circuit_connector_definitions[creative_mode_defines.names.entities.super_roboport] =
 	circuit_connector_definitions.create(
 	universal_connector_template,
@@ -1099,7 +1137,7 @@ data:extend(
 				shift = {0.96875, 0.609375},
 				direction_count = 16
 			},
-			working_sound = flying_robot_sounds(),
+			working_sound = flying_robot_sounds(0.7),
 			cargo_centered = {0.0, 0.2}
 		},
 		-- Super construction robot.
@@ -1273,7 +1311,7 @@ data:extend(
 					animation_speed = 0.3
 				}
 			},
-			working_sound = flying_robot_sounds(),
+			working_sound = flying_robot_sounds(0.7),
 			cargo_centered = {0.0, 0.2},
 			construction_vector = {0.30, 0.22}
 		},


### PR DESCRIPTION
Version 0.18.2 of Factorio broke the mod again...
The reason is that some former public functions have been moved to packages.
The `flying_robot_sounds()` function, this mod is using has been moved to `prototypes.entity.demo-sounds`  and renamed to `construction_robot()`. 
I don't think it is good practice to rely on demo code so I took the function and defined it as a local function for the mod.