### PR TITLE
Fix for new icon dimensions.

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -124,7 +124,8 @@ local function clone_enemy_entities_in_data_raw_and_create_recipe(raw_name)
 					type = "item",
 					name = item_name,
 					localised_name = entity_localised_name, -- Item does not know the entity's custom localised name, so we have to also use custom localised name for it.
-					icon_size = 32,
+					icon_size = 64,
+					icon_mipmaps = 4,
 					icon = entity.icon,
 					flags = flags,
 					subgroup = creative_mode_defines.names.item_subgroups.enemies,

--- a/prototypes/item.lua
+++ b/prototypes/item.lua
@@ -111,7 +111,8 @@ data:extend(
 			-- Creative cargo wagon
 			type = "item",
 			name = creative_mode_defines.names.items.creative_cargo_wagon,
-			icon_size = 32,
+			icon_size = 64,
+			icon_mipmaps = 4,
 			icons = {
 				{
 					icon = "__base__/graphics/icons/cargo-wagon.png",
@@ -128,7 +129,8 @@ data:extend(
 			-- Duplicating cargo wagon
 			type = "item",
 			name = creative_mode_defines.names.items.duplicating_cargo_wagon,
-			icon_size = 32,
+			icon_size = 64,
+			icon_mipmaps = 4,
 			icons = {
 				{
 					icon = "__base__/graphics/icons/cargo-wagon.png",
@@ -145,7 +147,8 @@ data:extend(
 			-- Void cargo wagon
 			type = "item",
 			name = creative_mode_defines.names.items.void_cargo_wagon,
-			icon_size = 32,
+			icon_size = 64,
+			icon_mipmaps = 4,
 			icons = {
 				{
 					icon = "__base__/graphics/icons/cargo-wagon.png",
@@ -162,7 +165,8 @@ data:extend(
 			-- Super logistic robot.
 			type = "item",
 			name = creative_mode_defines.names.items.super_logistic_robot,
-			icon_size = 32,
+			icon_size = 64,
+			icon_mipmaps = 4,
 			icons = {
 				{
 					icon = "__base__/graphics/icons/logistic-robot.png",
@@ -179,7 +183,8 @@ data:extend(
 			-- Super construction robot.
 			type = "item",
 			name = creative_mode_defines.names.items.super_construction_robot,
-			icon_size = 32,
+			icon_size = 64,
+			icon_mipmaps = 4,
 			icons = {
 				{
 					icon = "__base__/graphics/icons/construction-robot.png",
@@ -270,7 +275,8 @@ data:extend(
 			-- Heat source
 			type = "item",
 			name = creative_mode_defines.names.items.heat_source,
-			icon_size = 32,
+			icon_size = 64,
+			icon_mipmaps = 4,
 			icons = {
 				{
 					icon = "__base__/graphics/icons/heat-pipe.png",
@@ -287,7 +293,8 @@ data:extend(
 			-- Heat void
 			type = "item",
 			name = creative_mode_defines.names.items.heat_void,
-			icon_size = 32,
+			icon_size = 64,
+			icon_mipmaps = 4,
 			icons = {
 				{
 					icon = "__base__/graphics/icons/heat-pipe.png",


### PR DESCRIPTION
Fix for new icon dimensions. 

Fixed icons include:
- cargo wagon (3x)
- logistic robot
- construction robot
- heat pipe (2x)
- enemies (14x)

before:
![before](https://user-images.githubusercontent.com/21142074/73462773-94d1bb00-437c-11ea-866a-8cd3de7a4403.png)
after:
![after](https://user-images.githubusercontent.com/21142074/73462771-94d1bb00-437c-11ea-8d93-17707faf59b9.png)

